### PR TITLE
🔀 :: (entry-251) 원서 최종제출 확인된 지역 로직 변경

### DIFF
--- a/application-domain/src/main/kotlin/hs/kr/equus/application/domain/application/usecase/GetApplicationStatusByRegionUseCase.kt
+++ b/application-domain/src/main/kotlin/hs/kr/equus/application/domain/application/usecase/GetApplicationStatusByRegionUseCase.kt
@@ -19,7 +19,7 @@ class GetApplicationStatusByRegionUseCase(
         "울산" to { response: GetApplicationStatusByRegionResponse -> response.copy(ulsan = response.ulsan + 1) },
         "인천" to { response: GetApplicationStatusByRegionResponse -> response.copy(incheon = response.incheon + 1) },
         "제주" to { response: GetApplicationStatusByRegionResponse -> response.copy(jeju = response.jeju + 1) },
-        "강원특별자치도" to { response: GetApplicationStatusByRegionResponse -> response.copy(gangwonDo = response.gangwonDo + 1) },
+        "강원" to { response: GetApplicationStatusByRegionResponse -> response.copy(gangwonDo = response.gangwonDo + 1) },
         "경기" to { response: GetApplicationStatusByRegionResponse -> response.copy(gyeonggiDo = response.gyeonggiDo + 1) },
         "경남" to { response: GetApplicationStatusByRegionResponse -> response.copy(gyeongsangnamDo = response.gyeongsangnamDo + 1) },
         "경북" to { response: GetApplicationStatusByRegionResponse -> response.copy(gyeongsangbukDo = response.gyeongsangbukDo + 1) },
@@ -49,7 +49,7 @@ class GetApplicationStatusByRegionUseCase(
         address: String
     ): GetApplicationStatusByRegionResponse {
         var updatedResponse = response
-        val applicantRegion = address.split(" ")[0]
+        val applicantRegion = address.substring(0 until 2)
 
         regionListMapping.forEach { (region, update) ->
             if (applicantRegion == region) {

--- a/application-domain/src/test/kotlin/hs/kr/equus/application/domain/application/usecase/GetApplicationStatusByRegionUseCaseTest.kt
+++ b/application-domain/src/test/kotlin/hs/kr/equus/application/domain/application/usecase/GetApplicationStatusByRegionUseCaseTest.kt
@@ -37,7 +37,20 @@ class GetApplicationStatusByRegionUseCaseTest {
             Application(
                 streetAddress = "대구 동성로",
                 userId = UUID.randomUUID()
+            ),
+            Application(
+                streetAddress = "대구 동성로",
+                userId = UUID.randomUUID()
+            ),
+            Application(
+                streetAddress = "전북특별자치도 전주시",
+                userId = UUID.randomUUID()
+            ),
+            Application(
+                streetAddress = "강원특별자치도 양구군",
+                userId = UUID.randomUUID()
             )
+
         )
 
         Mockito.`when`(queryApplicationInfoListByStatusIsSubmittedPort.queryApplicationInfoListByStatusIsSubmitted(true))
@@ -48,18 +61,18 @@ class GetApplicationStatusByRegionUseCaseTest {
         val response = GetApplicationStatusByRegionResponse(
             seoul = 2,
             busan = 2,
-            daegu = 1,
+            daegu = 2,
             gwangju = 0,
             daejeon = 0,
             ulsan = 0,
             incheon = 0,
             jeju = 0,
-            gangwonDo = 0,
+            gangwonDo = 1,
             gyeonggiDo = 0,
             gyeongsangnamDo = 0,
             gyeongsangbukDo = 0,
             jeollanamDo = 0,
-            jeollabukDo = 0,
+            jeollabukDo = 1,
             chungcheongnamDo = 0,
             chungcheongbukDo = 0,
             sejong = 0


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- "Gangwon" 지역의 키 이름을 "강원특별자치도"에서 "강원"으로 변경하여 지역 식별 프로세스를 간소화했습니다.
	- 주소에서 지원자의 지역을 추출하는 로직을 개선했습니다.

- **테스트**
	- `GetApplicationStatusByRegionUseCaseTest` 클래스의 테스트 메서드 업데이트, 새로운 `Application` 인스턴스를 추가하고 예상 값을 조정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->